### PR TITLE
Refactor to modularize the telemetry by components

### DIFF
--- a/Yuneec_SDK_iOS.xcodeproj/project.pbxproj
+++ b/Yuneec_SDK_iOS.xcodeproj/project.pbxproj
@@ -18,12 +18,15 @@
 		082C06751E150ED400BDD785 /* YNCSDKInternal.mm in Sources */ = {isa = PBXBuildFile; fileRef = 082C06671E150ED400BDD785 /* YNCSDKInternal.mm */; };
 		082C06761E150ED400BDD785 /* YNCSDKOffboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 082C06681E150ED400BDD785 /* YNCSDKOffboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		082C06771E150ED400BDD785 /* YNCSDKOffboard.mm in Sources */ = {isa = PBXBuildFile; fileRef = 082C06691E150ED400BDD785 /* YNCSDKOffboard.mm */; };
-		082C06781E150ED400BDD785 /* YNCSDKTelemetry.h in Headers */ = {isa = PBXBuildFile; fileRef = 082C066A1E150ED400BDD785 /* YNCSDKTelemetry.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		082C06791E150ED400BDD785 /* YNCSDKTelemetry.mm in Sources */ = {isa = PBXBuildFile; fileRef = 082C066B1E150ED400BDD785 /* YNCSDKTelemetry.mm */; };
+		082C06781E150ED400BDD785 /* YNCSDKAircraftTelemetry.h in Headers */ = {isa = PBXBuildFile; fileRef = 082C066A1E150ED400BDD785 /* YNCSDKAircraftTelemetry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		082C06791E150ED400BDD785 /* YNCSDKAircraftTelemetry.mm in Sources */ = {isa = PBXBuildFile; fileRef = 082C066B1E150ED400BDD785 /* YNCSDKAircraftTelemetry.mm */; };
 		0842318D1F58725F001E53DA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0842318C1F58725F001E53DA /* Security.framework */; };
 		0842318F1F587272001E53DA /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0842318E1F587272001E53DA /* libz.tbd */; };
 		1F02BB9D1FBD08DA00F9B384 /* libcurl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0842318A1F5855F5001E53DA /* libcurl.a */; };
 		1F02BB9F1FBD08DA00F9B384 /* libdronecore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F02BB9E1FBD08DA00F9B384 /* libdronecore.a */; };
+		1F613C06201680A200A2DEC4 /* YNCSDKAircraftBattery.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F613C05201680A200A2DEC4 /* YNCSDKAircraftBattery.mm */; };
+		1F613C09201686ED00A2DEC4 /* YNCSDKAircraftHealth.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F613C07201686ED00A2DEC4 /* YNCSDKAircraftHealth.mm */; };
+		1F613C0A201686ED00A2DEC4 /* YNCSDKAircraftHealth.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F613C08201686ED00A2DEC4 /* YNCSDKAircraftHealth.h */; };
 		B9FFEDE41E1F658A008458AE /* YNCSDKMission.h in Headers */ = {isa = PBXBuildFile; fileRef = B9FFEDE21E1F658A008458AE /* YNCSDKMission.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9FFEDE51E1F658A008458AE /* YNCSDKMission.mm in Sources */ = {isa = PBXBuildFile; fileRef = B9FFEDE31E1F658A008458AE /* YNCSDKMission.mm */; };
 		F4B49D751E81037100C44328 /* YNCSDKCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B49D731E81037100C44328 /* YNCSDKCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -45,14 +48,18 @@
 		082C06671E150ED400BDD785 /* YNCSDKInternal.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YNCSDKInternal.mm; sourceTree = "<group>"; };
 		082C06681E150ED400BDD785 /* YNCSDKOffboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YNCSDKOffboard.h; sourceTree = "<group>"; };
 		082C06691E150ED400BDD785 /* YNCSDKOffboard.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YNCSDKOffboard.mm; sourceTree = "<group>"; };
-		082C066A1E150ED400BDD785 /* YNCSDKTelemetry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YNCSDKTelemetry.h; sourceTree = "<group>"; };
-		082C066B1E150ED400BDD785 /* YNCSDKTelemetry.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YNCSDKTelemetry.mm; sourceTree = "<group>"; };
+		082C066A1E150ED400BDD785 /* YNCSDKAircraftTelemetry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YNCSDKAircraftTelemetry.h; sourceTree = "<group>"; };
+		082C066B1E150ED400BDD785 /* YNCSDKAircraftTelemetry.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YNCSDKAircraftTelemetry.mm; sourceTree = "<group>"; };
 		082C067D1E155F7D00BDD785 /* libdronelink.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronelink.a; path = "../Yuneec-SDK/lib/ios/libdronelink.a"; sourceTree = "<group>"; };
 		082C06871E157A1500BDD785 /* libdronelink.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronelink.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronelink.a"; sourceTree = "<group>"; };
 		0842318A1F5855F5001E53DA /* libcurl.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcurl.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libcurl.a"; sourceTree = "<group>"; };
 		0842318C1F58725F001E53DA /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		0842318E1F587272001E53DA /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		1F02BB9E1FBD08DA00F9B384 /* libdronecore.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore.a"; sourceTree = "<group>"; };
+		1F613C0020167EBF00A2DEC4 /* YNCSDKAircraftBattery.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YNCSDKAircraftBattery.h; sourceTree = "<group>"; };
+		1F613C05201680A200A2DEC4 /* YNCSDKAircraftBattery.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = YNCSDKAircraftBattery.mm; sourceTree = "<group>"; };
+		1F613C07201686ED00A2DEC4 /* YNCSDKAircraftHealth.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = YNCSDKAircraftHealth.mm; sourceTree = "<group>"; };
+		1F613C08201686ED00A2DEC4 /* YNCSDKAircraftHealth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YNCSDKAircraftHealth.h; sourceTree = "<group>"; };
 		B9FFEDE21E1F658A008458AE /* YNCSDKMission.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YNCSDKMission.h; sourceTree = "<group>"; };
 		B9FFEDE31E1F658A008458AE /* YNCSDKMission.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YNCSDKMission.mm; sourceTree = "<group>"; };
 		F4B49D731E81037100C44328 /* YNCSDKCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YNCSDKCamera.h; sourceTree = "<group>"; };
@@ -108,14 +115,18 @@
 				082C06671E150ED400BDD785 /* YNCSDKInternal.mm */,
 				082C06681E150ED400BDD785 /* YNCSDKOffboard.h */,
 				082C06691E150ED400BDD785 /* YNCSDKOffboard.mm */,
-				082C066A1E150ED400BDD785 /* YNCSDKTelemetry.h */,
-				082C066B1E150ED400BDD785 /* YNCSDKTelemetry.mm */,
+				082C066A1E150ED400BDD785 /* YNCSDKAircraftTelemetry.h */,
+				082C066B1E150ED400BDD785 /* YNCSDKAircraftTelemetry.mm */,
 				B9FFEDE21E1F658A008458AE /* YNCSDKMission.h */,
 				B9FFEDE31E1F658A008458AE /* YNCSDKMission.mm */,
 				080E8C411E56EDE600E48132 /* YNCSDKMissionItem.h */,
 				080E8C421E56EDE600E48132 /* YNCSDKMissionItem.mm */,
 				082C06581E150EAB00BDD785 /* Yuneec_SDK_iOS.h */,
 				082C06591E150EAB00BDD785 /* Info.plist */,
+				1F613C0020167EBF00A2DEC4 /* YNCSDKAircraftBattery.h */,
+				1F613C05201680A200A2DEC4 /* YNCSDKAircraftBattery.mm */,
+				1F613C07201686ED00A2DEC4 /* YNCSDKAircraftHealth.mm */,
+				1F613C08201686ED00A2DEC4 /* YNCSDKAircraftHealth.h */,
 			);
 			path = Yuneec_SDK_iOS;
 			sourceTree = "<group>";
@@ -143,7 +154,8 @@
 				082C065A1E150EAB00BDD785 /* Yuneec_SDK_iOS.h in Headers */,
 				082C066E1E150ED400BDD785 /* YNCSDKAction.h in Headers */,
 				0817D88A1E977F850062ADCF /* YNCSDKGimbal.h in Headers */,
-				082C06781E150ED400BDD785 /* YNCSDKTelemetry.h in Headers */,
+				082C06781E150ED400BDD785 /* YNCSDKAircraftTelemetry.h in Headers */,
+				1F613C0A201686ED00A2DEC4 /* YNCSDKAircraftHealth.h in Headers */,
 				082C06701E150ED400BDD785 /* YNCSDKConnection.h in Headers */,
 				082C06761E150ED400BDD785 /* YNCSDKOffboard.h in Headers */,
 				F4B49D751E81037100C44328 /* YNCSDKCamera.h in Headers */,
@@ -239,14 +251,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F613C09201686ED00A2DEC4 /* YNCSDKAircraftHealth.mm in Sources */,
 				082C06771E150ED400BDD785 /* YNCSDKOffboard.mm in Sources */,
 				082C066F1E150ED400BDD785 /* YNCSDKAction.mm in Sources */,
 				082C06751E150ED400BDD785 /* YNCSDKInternal.mm in Sources */,
 				082C06711E150ED400BDD785 /* YNCSDKConnection.mm in Sources */,
 				F4F34C9E1E2F4CBE0022D1B8 /* YNCSDKGimbal.mm in Sources */,
+				1F613C06201680A200A2DEC4 /* YNCSDKAircraftBattery.mm in Sources */,
 				080E8C441E56EDE600E48132 /* YNCSDKMissionItem.mm in Sources */,
 				B9FFEDE51E1F658A008458AE /* YNCSDKMission.mm in Sources */,
-				082C06791E150ED400BDD785 /* YNCSDKTelemetry.mm in Sources */,
+				082C06791E150ED400BDD785 /* YNCSDKAircraftTelemetry.mm in Sources */,
 				F4B49D761E81037100C44328 /* YNCSDKCamera.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Yuneec_SDK_iOS/YNCSDKAircraftBattery.h
+++ b/Yuneec_SDK_iOS/YNCSDKAircraftBattery.h
@@ -1,0 +1,52 @@
+//
+//  YNCSDKAircraftBattery.h
+//  Yuneec_SDK_iOS
+//
+//  Copyright © 2018 Yuneec. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ This class manages the real-time status of the battery component.
+ */
+@interface YNCBattery : NSObject
+
+/**
+ Battery voltage (in volts)
+ */
+@property (nonatomic, assign) float voltageV;
+
+/**
+ Battery remaining (as a percentage)
+ */
+@property (nonatomic, assign) float remainingPercent;
+
+@end
+
+/**
+ * This protocol provides delegate methods to subscribe to battery status updates.
+ */
+@protocol YNCSDKBatteryDelegate <NSObject>
+
+/**
+ * Receives battery status updates.
+ *
+ * @param battery the battery object
+ */
+- (void)onBatteryUpdate:(YNCBattery *)battery;
+@end
+
+/**
+ This class provides a method to subscribe to battery status updates.
+ */
+@interface YNCSDKBattery : NSObject
+
+/**
+ * Subscribes to battery status updates.
+ *
+ * @param delegate The Battery delegate object
+ */
+- (void)subscribe:(id<YNCSDKBatteryDelegate>) delegate;
+@end
+

--- a/Yuneec_SDK_iOS/YNCSDKAircraftBattery.mm
+++ b/Yuneec_SDK_iOS/YNCSDKAircraftBattery.mm
@@ -1,0 +1,44 @@
+//
+//  YNCSDKAircraftBattery.mm
+//  Yuneec_SDK_iOS
+//
+//  Copyright © 2018 Yuneec. All rights reserved.
+//
+
+/** @brief YNCSDKAircraftBattery  implementation file, Subscribe Battery status*/
+
+#import "YNCSDKAircraftBattery.h"
+#import "YNCSDKInternal.h"
+
+
+#include <dronecore/dronecore.h>
+
+using namespace dronecore;
+using namespace std::placeholders;
+
+static id <YNCSDKBatteryDelegate> _batteryDelegate;
+
+#pragma mark Receive battery data
+void receive_battery(Telemetry::Battery battery) {
+    YNCBattery *tmpBattery = [YNCBattery new];
+    tmpBattery.voltageV = battery.voltage_v;
+    tmpBattery.remainingPercent = battery.remaining_percent;
+    
+    if (_batteryDelegate && [_batteryDelegate respondsToSelector:@selector(onBatteryUpdate:)]) {
+        [_batteryDelegate onBatteryUpdate:tmpBattery];
+    }
+}
+
+@implementation YNCBattery
+@end
+
+@implementation YNCSDKBattery
+
+- (void)subscribe:(id<YNCSDKBatteryDelegate>) delegate {
+    _batteryDelegate = delegate;
+    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    dc->device().telemetry().battery_async(&receive_battery);
+}
+
+@end
+

--- a/Yuneec_SDK_iOS/YNCSDKAircraftHealth.h
+++ b/Yuneec_SDK_iOS/YNCSDKAircraftHealth.h
@@ -1,0 +1,99 @@
+//
+//  YNCSDKAircraftHealth.h
+//  Yuneec_SDK_iOS
+//
+//  Copyright © 2018 Yuneec. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ This class contains the drone's component health and status.
+ */
+@interface YNCHealth : NSObject
+
+/**
+ State of the gyroscope calibration
+ */
+@property (nonatomic, assign) BOOL gyrometerCalibrationOk;
+
+/**
+ State of the accelerometer calibration
+ */
+@property (nonatomic, assign) BOOL accelerometerCalibrationOk;
+
+/**
+ State of the magnetometer calibration
+ */
+@property (nonatomic, assign) BOOL magnetometerCalibrationOk;
+
+/**
+ State of the level calibration
+ */
+@property (nonatomic, assign) BOOL levelCalibrationOk;
+
+/**
+ Status of the local position
+ */
+@property (nonatomic, assign) BOOL localPositionOk;
+
+/**
+ Status of the global position
+ */
+@property (nonatomic, assign) BOOL globalPositionOk;
+
+/**
+ Status of the home position
+ */
+@property (nonatomic, assign) BOOL homePositionOk;
+
+@end
+
+/**
+ This delegate provides health status updates of the drone.
+ */
+@protocol YNCSDKAircraftHealthDelegate <NSObject>
+/**
+ Receives health status updates.
+ 
+ @param health The health status
+ */
+- (void)onHealthUpdate:(YNCHealth *)health;
+@end
+
+/**
+ This class provides a method to subscribe to drone health updates.
+ */
+@interface YNCSDKAircraftHealth: NSObject
+/**
+ * Subscribes to drone health updates.
+ *
+ * @param delegate The Drone Health delegate object
+ */
+- (void)subscribe:(id<YNCSDKAircraftHealthDelegate>) delegate;
+@end
+
+/**
+ This delegate provides the overall health status.
+ */
+@protocol YNCSDKAircraftHealthAllOkDelegate <NSObject>
+/**
+ Receives overall health status updates.
+ 
+ @param healthAllOk true if all health flags are ok
+ */
+- (void)onHealthAllOkUpdate:(BOOL)healthAllOk;
+@end
+
+/**
+ This class provides a method to subscribe to overall health status updates.
+ */
+@interface YNCSDKAircraftHealthAllOk: NSObject
+/**
+ * Subscribes to overall health status updates.
+ *
+ * @param delegate The Overall Health delegate object
+ */
+- (void)subscribe:(id<YNCSDKAircraftHealthAllOkDelegate>) delegate;
+@end
+

--- a/Yuneec_SDK_iOS/YNCSDKAircraftHealth.mm
+++ b/Yuneec_SDK_iOS/YNCSDKAircraftHealth.mm
@@ -1,0 +1,72 @@
+//
+//  YNCSDKAircraftHealth.mm
+//  Yuneec_SDK_iOS
+//
+//  Copyright © 2018 Yuneec. All rights reserved.
+//
+
+/** @brief YNCSDKAircraftHealth implementation file, Subscribe Aircraft Health status*/
+
+
+#import "YNCSDKAircraftHealth.h"
+#import "YNCSDKInternal.h"
+
+
+#include <dronecore/dronecore.h>
+
+using namespace dronecore;
+using namespace std::placeholders;
+
+static id <YNCSDKAircraftHealthDelegate> _healthDelegate;
+
+static id <YNCSDKAircraftHealthAllOkDelegate> _healthAllOkDelegate;
+
+#pragma mark Receive Health information
+void receive_health(Telemetry::Health health) {
+    YNCHealth *tmpHealth = [YNCHealth new];
+    tmpHealth.homePositionOk = health.home_position_ok;
+    tmpHealth.localPositionOk = health.local_position_ok;
+    tmpHealth.globalPositionOk = health.global_position_ok;
+    tmpHealth.levelCalibrationOk = health.level_calibration_ok;
+    tmpHealth.gyrometerCalibrationOk = health.gyrometer_calibration_ok;
+    tmpHealth.magnetometerCalibrationOk = health.magnetometer_calibration_ok;
+    tmpHealth.accelerometerCalibrationOk = health.accelerometer_calibration_ok;
+    
+    if (_healthDelegate &&
+        [_healthDelegate respondsToSelector:@selector(onHealthUpdate:)]) {
+        [_healthDelegate onHealthUpdate:tmpHealth];
+    }
+}
+
+#pragma mark Receive health all information
+void receive_healthAllOk(bool healthAllOk) {
+    if (_healthAllOkDelegate && [_healthAllOkDelegate respondsToSelector:@selector(onHealthAllOkUpdate:)]) {
+        [_healthAllOkDelegate onHealthAllOkUpdate:healthAllOk];
+    }
+}
+
+@implementation YNCHealth
+@end
+
+@implementation YNCSDKAircraftHealth
+
+- (void)subscribe:(id<YNCSDKAircraftHealthDelegate>) delegate {
+    _healthDelegate = delegate;
+    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    dc->device().telemetry().health_async(&receive_health);
+}
+
+@end
+
+@implementation YNCSDKAircraftHealthAllOk
+
+- (void)subscribe:(id<YNCSDKAircraftHealthAllOkDelegate>) delegate {
+    _healthAllOkDelegate = delegate;
+    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    dc->device().telemetry().health_all_ok_async(&receive_healthAllOk);
+}
+
+@end
+
+
+

--- a/Yuneec_SDK_iOS/YNCSDKAircraftTelemetry.h
+++ b/Yuneec_SDK_iOS/YNCSDKAircraftTelemetry.h
@@ -1,5 +1,5 @@
 /*
- * YNCSDKTelemetry.h
+ * YNCSDKAircraftTelemetry.h
  * YUNEEC_SDK_IOS
  *
  * Copyright @ 2016 Yuneec.
@@ -8,49 +8,6 @@
 */
 
 #import <Foundation/Foundation.h>
-
-/**
- This class manages the real-time status of the battery component.
- */
-@interface YNCBattery : NSObject
-
-    /**
-     Battery voltage (in volts)
-     */
-    @property (nonatomic, assign) float voltageV;
-
-    /**
-     Battery remaining (as a percentage)
-     */
-    @property (nonatomic, assign) float remainingPercent;
-
-@end
-
-/**
- * This protocol provides delegate methods to subscribe to battery status updates.
- */
-@protocol YNCSDKTelemetryBatteryDelegate <NSObject>
-
-/**
- * Receives battery status updates.
- *
- * @param battery the battery object
- */
-- (void)onBatteryUpdate:(YNCBattery *)battery;
-@end
-
-/**
- This class provides a method to subscribe to battery status updates.
- */
-@interface YNCSDKTelemetryBattery : NSObject
-
- /**
- * Subscribes to battery status updates.
- *
- * @param delegate The Battery delegate object
- */
-- (void)subscribe:(id<YNCSDKTelemetryBatteryDelegate>) delegate;
-@end
 
 /**
  This class contains fields associated with the drone's position.
@@ -497,72 +454,6 @@ typedef NS_ENUM (NSInteger, YNCTelemetryFlightMode) {
 @end
 
 /**
- This class contains the drone's component health and status.
- */
-@interface YNCHealth : NSObject
-
-    /**
-     State of the gyroscope calibration
-     */
-    @property (nonatomic, assign) BOOL gyrometerCalibrationOk;
-
-    /**
-     State of the accelerometer calibration
-     */
-    @property (nonatomic, assign) BOOL accelerometerCalibrationOk;
-
-    /**
-     State of the magnetometer calibration
-     */
-    @property (nonatomic, assign) BOOL magnetometerCalibrationOk;
-
-    /**
-     State of the level calibration
-     */
-    @property (nonatomic, assign) BOOL levelCalibrationOk;
-
-    /**
-     Status of the local position
-     */
-    @property (nonatomic, assign) BOOL localPositionOk;
-
-    /**
-     Status of the global position
-     */
-    @property (nonatomic, assign) BOOL globalPositionOk;
-
-    /**
-     Status of the home position
-     */
-    @property (nonatomic, assign) BOOL homePositionOk;
-
-@end
-
-/**
- This delegate provides health status updates of the drone.
- */
-@protocol YNCSDKTelemetryHealthDelegate <NSObject>
-/**
- Receives health status updates.
- 
- @param health The health status
- */
-- (void)onHealthUpdate:(YNCHealth *)health;
-@end
-
-/**
- This class provides a method to subscribe to drone health updates.
- */
-@interface YNCSDKTelemetryHealth: NSObject
- /**
- * Subscribes to drone health updates.
- *
- * @param delegate The Drone Health delegate object
- */  
-- (void)subscribe:(id<YNCSDKTelemetryHealthDelegate>) delegate;
-@end
-
-/**
  This delegate provides armed status updates.
  */
 @protocol YNCSDKTelemetryArmedDelegate <NSObject>
@@ -586,26 +477,3 @@ typedef NS_ENUM (NSInteger, YNCTelemetryFlightMode) {
 - (void)subscribe:(id<YNCSDKTelemetryArmedDelegate>) delegate;
 @end
 
-/**
- This delegate provides the overall health status.
- */
-@protocol YNCSDKTelemetryHealthAllOkDelegate <NSObject>
-/**
- Receives overall health status updates.
- 
- @param healthAllOk true if all health flags are ok
- */
-- (void)onHealthAllOkUpdate:(BOOL)healthAllOk;
-@end
-
-/**
- This class provides a method to subscribe to overall health status updates.
- */
-@interface YNCSDKTelemetryHealthAllOk: NSObject
-/**
- * Subscribes to overall health status updates.
- *
- * @param delegate The Overall Health delegate object
- */
-- (void)subscribe:(id<YNCSDKTelemetryHealthAllOkDelegate>) delegate;
-@end

--- a/Yuneec_SDK_iOS/YNCSDKAircraftTelemetry.mm
+++ b/Yuneec_SDK_iOS/YNCSDKAircraftTelemetry.mm
@@ -1,6 +1,6 @@
-/** @brief YNCSDKTelemetry  implementation file, Subscribe Drone Telemetry status*/
+/** @brief YNCSDKAircraftTelemetry implementation file, Subscribe Drone Telemetry status*/
 
-#import "YNCSDKTelemetry.h"
+#import "YNCSDKAircraftTelemetry.h"
 #import "YNCSDKInternal.h"
 
 
@@ -9,7 +9,6 @@
 using namespace dronecore;
 using namespace std::placeholders;
 
-static id <YNCSDKTelemetryBatteryDelegate> _batteryDelegate;
 static id <YNCSDKTelemetryPositionDelegate> _positionDelegate;
 static id <YNCSDKTelemetryGroundSpeedNEDDelegate> _groundSpeedNEDDelegate;
 static id <YNCSDKTelemetryGPSInfoDelegate> _gpsInfoDelegate;
@@ -21,21 +20,8 @@ static id <YNCSDKTelemetryCameraAttitudeEulerAngleDelegate> _cameraAttitudeEuler
 static id <YNCSDKTelemetryCameraAttitudeQuaternionDelegate> _cameraAttitudeQuaternionDelegate;
 static id <YNCSDKTelemetryRCStatusDelegate> _rcStatusDelegate;
 static id <YNCSDKTelemetryFlightModeDelegate> _flightModeDelegate;
-static id <YNCSDKTelemetryHealthDelegate> _healthDelegate;
 static id <YNCSDKTelemetryArmedDelegate> _armedDelegate;
-static id <YNCSDKTelemetryHealthAllOkDelegate> _healthAllOkDelegate;
 
-
-#pragma mark Receive battery data
-void receive_battery(Telemetry::Battery battery) {
-    YNCBattery *tmpBattery = [YNCBattery new];
-    tmpBattery.voltageV = battery.voltage_v;
-    tmpBattery.remainingPercent = battery.remaining_percent;
-    
-    if (_batteryDelegate && [_batteryDelegate respondsToSelector:@selector(onBatteryUpdate:)]) {
-        [_batteryDelegate onBatteryUpdate:tmpBattery];
-    }
-}
 
 #pragma mark Receive Position information
 void receive_position(Telemetry::Position position) {
@@ -209,49 +195,12 @@ void receive_flightMode(Telemetry::FlightMode flightMode) {
     }
 }
 
-#pragma mark Receive Health information
-void receive_health(Telemetry::Health health) {
-    YNCHealth *tmpHealth = [YNCHealth new];
-    tmpHealth.homePositionOk = health.home_position_ok;
-    tmpHealth.localPositionOk = health.local_position_ok;
-    tmpHealth.globalPositionOk = health.global_position_ok;
-    tmpHealth.levelCalibrationOk = health.level_calibration_ok;
-    tmpHealth.gyrometerCalibrationOk = health.gyrometer_calibration_ok;
-    tmpHealth.magnetometerCalibrationOk = health.magnetometer_calibration_ok;
-    tmpHealth.accelerometerCalibrationOk = health.accelerometer_calibration_ok;
-    
-    if (_healthDelegate &&
-        [_healthDelegate respondsToSelector:@selector(onHealthUpdate:)]) {
-        [_healthDelegate onHealthUpdate:tmpHealth];
-    }
-}
-
 #pragma mark Receive armed information
 void receive_armed(bool armed) {
     if (_armedDelegate && [_armedDelegate respondsToSelector:@selector(onArmedUpdate:)]) {
         [_armedDelegate onArmedUpdate:armed];
     }
 }
-
-#pragma mark Receive health all information
-void receive_healthAllOk(bool healthAllOk) {
-    if (_healthAllOkDelegate && [_healthAllOkDelegate respondsToSelector:@selector(onHealthAllOkUpdate:)]) {
-        [_healthAllOkDelegate onHealthAllOkUpdate:healthAllOk];
-    }
-}
-
-@implementation YNCBattery
-@end
-
-@implementation YNCSDKTelemetryBattery
-
-- (void)subscribe:(id<YNCSDKTelemetryBatteryDelegate>) delegate {
-    _batteryDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().battery_async(&receive_battery);
-}
-
-@end
 
 @implementation YNCPosition
 @end
@@ -381,35 +330,12 @@ void receive_healthAllOk(bool healthAllOk) {
 
 @end
 
-@implementation YNCHealth
-@end
-
-@implementation YNCSDKTelemetryHealth
-
-- (void)subscribe:(id<YNCSDKTelemetryHealthDelegate>) delegate {
-    _healthDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().health_async(&receive_health);
-}
-
-@end
-
 @implementation YNCSDKTelemetryArmed
 
 - (void)subscribe:(id<YNCSDKTelemetryArmedDelegate>) delegate {
     _armedDelegate = delegate;
     DroneCore *dc = [[YNCSDKInternal instance] dc];
     dc->device().telemetry().armed_async(&receive_armed);
-}
-
-@end
-
-@implementation YNCSDKTelemetryHealthAllOk
-
-- (void)subscribe:(id<YNCSDKTelemetryHealthAllOkDelegate>) delegate {
-    _healthAllOkDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().health_all_ok_async(&receive_healthAllOk);
 }
 
 @end

--- a/download-dronecore.sh
+++ b/download-dronecore.sh
@@ -2,7 +2,7 @@
 
 set -e # fail on errors
 
-dronecore_filename=DroneCore-iOS-v0.9.0-Release.zip
+dronecore_filename=DroneCore-iOS-v0.10.0-Release.zip
 unzip_dir=Yuneec_SDK_iOS/libs/Yuneec-SDK
 
 downloaded=false


### PR DESCRIPTION
1. Separate the telemetry components by battery, health. 
  For modularity. 