### PR TITLE
Changes after DroneCore refactor

### DIFF
--- a/Yuneec_SDK_iOS.xcodeproj/project.pbxproj
+++ b/Yuneec_SDK_iOS.xcodeproj/project.pbxproj
@@ -10,6 +10,16 @@
 		080E8C431E56EDE600E48132 /* YNCSDKMissionItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 080E8C411E56EDE600E48132 /* YNCSDKMissionItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		080E8C441E56EDE600E48132 /* YNCSDKMissionItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 080E8C421E56EDE600E48132 /* YNCSDKMissionItem.mm */; };
 		0817D88A1E977F850062ADCF /* YNCSDKGimbal.h in Headers */ = {isa = PBXBuildFile; fileRef = F4F34C9B1E2F4CBE0022D1B8 /* YNCSDKGimbal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		081FEE8320347F21007422E2 /* libdronecore_camera.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 081FEE72203475D2007422E2 /* libdronecore_camera.a */; };
+		081FEE8520347F21007422E2 /* libdronecore_gimbal.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 081FEE6F203475D2007422E2 /* libdronecore_gimbal.a */; };
+		081FEE8620347F21007422E2 /* libdronecore_info.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 081FEE6E203475D2007422E2 /* libdronecore_info.a */; };
+		081FEE8920347F21007422E2 /* libdronecore_mission.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 081FEE70203475D2007422E2 /* libdronecore_mission.a */; };
+		081FEE8A20347F21007422E2 /* libdronecore_offboard.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 081FEE6D203475D2007422E2 /* libdronecore_offboard.a */; };
+		081FEE8B20347F21007422E2 /* libdronecore_telemetry.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 081FEE74203475D2007422E2 /* libdronecore_telemetry.a */; };
+		081FEE8F20347F21007422E2 /* libdronecore_action.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 081FEE8E20347F21007422E2 /* libdronecore_action.a */; };
+		081FEE9020347F38007422E2 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0842318C1F58725F001E53DA /* Security.framework */; };
+		081FEE9120347F43007422E2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0842318E1F587272001E53DA /* libz.tbd */; };
+		08272CC9202B3B8A00C9B3F4 /* libdronecore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F02BB9E1FBD08DA00F9B384 /* libdronecore.a */; };
 		082C065A1E150EAB00BDD785 /* Yuneec_SDK_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 082C06581E150EAB00BDD785 /* Yuneec_SDK_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		082C066E1E150ED400BDD785 /* YNCSDKAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 082C06601E150ED400BDD785 /* YNCSDKAction.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		082C066F1E150ED400BDD785 /* YNCSDKAction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 082C06611E150ED400BDD785 /* YNCSDKAction.mm */; };
@@ -20,10 +30,7 @@
 		082C06771E150ED400BDD785 /* YNCSDKOffboard.mm in Sources */ = {isa = PBXBuildFile; fileRef = 082C06691E150ED400BDD785 /* YNCSDKOffboard.mm */; };
 		082C06781E150ED400BDD785 /* YNCSDKTelemetry.h in Headers */ = {isa = PBXBuildFile; fileRef = 082C066A1E150ED400BDD785 /* YNCSDKTelemetry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		082C06791E150ED400BDD785 /* YNCSDKTelemetry.mm in Sources */ = {isa = PBXBuildFile; fileRef = 082C066B1E150ED400BDD785 /* YNCSDKTelemetry.mm */; };
-		0842318D1F58725F001E53DA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0842318C1F58725F001E53DA /* Security.framework */; };
-		0842318F1F587272001E53DA /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0842318E1F587272001E53DA /* libz.tbd */; };
 		1F02BB9D1FBD08DA00F9B384 /* libcurl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0842318A1F5855F5001E53DA /* libcurl.a */; };
-		1F02BB9F1FBD08DA00F9B384 /* libdronecore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F02BB9E1FBD08DA00F9B384 /* libdronecore.a */; };
 		B9FFEDE41E1F658A008458AE /* YNCSDKMission.h in Headers */ = {isa = PBXBuildFile; fileRef = B9FFEDE21E1F658A008458AE /* YNCSDKMission.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9FFEDE51E1F658A008458AE /* YNCSDKMission.mm in Sources */ = {isa = PBXBuildFile; fileRef = B9FFEDE31E1F658A008458AE /* YNCSDKMission.mm */; };
 		F4B49D751E81037100C44328 /* YNCSDKCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B49D731E81037100C44328 /* YNCSDKCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -34,6 +41,19 @@
 /* Begin PBXFileReference section */
 		080E8C411E56EDE600E48132 /* YNCSDKMissionItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YNCSDKMissionItem.h; sourceTree = "<group>"; };
 		080E8C421E56EDE600E48132 /* YNCSDKMissionItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = YNCSDKMissionItem.mm; sourceTree = "<group>"; };
+		081FEE6A203475D1007422E2 /* libdronecore_update.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_update.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_update.a"; sourceTree = "<group>"; };
+		081FEE6B203475D1007422E2 /* libdronecore_calibration.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_calibration.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_calibration.a"; sourceTree = "<group>"; };
+		081FEE6C203475D1007422E2 /* libdronecore_yuneec_st16.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_yuneec_st16.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_yuneec_st16.a"; sourceTree = "<group>"; };
+		081FEE6D203475D2007422E2 /* libdronecore_offboard.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_offboard.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_offboard.a"; sourceTree = "<group>"; };
+		081FEE6E203475D2007422E2 /* libdronecore_info.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_info.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_info.a"; sourceTree = "<group>"; };
+		081FEE6F203475D2007422E2 /* libdronecore_gimbal.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_gimbal.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_gimbal.a"; sourceTree = "<group>"; };
+		081FEE70203475D2007422E2 /* libdronecore_mission.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_mission.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_mission.a"; sourceTree = "<group>"; };
+		081FEE71203475D2007422E2 /* libdronecore_logging.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_logging.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_logging.a"; sourceTree = "<group>"; };
+		081FEE72203475D2007422E2 /* libdronecore_camera.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_camera.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_camera.a"; sourceTree = "<group>"; };
+		081FEE73203475D2007422E2 /* libdronecore_manual.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_manual.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_manual.a"; sourceTree = "<group>"; };
+		081FEE74203475D2007422E2 /* libdronecore_telemetry.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_telemetry.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_telemetry.a"; sourceTree = "<group>"; };
+		081FEE75203475D2007422E2 /* libdronecore_follow_me.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_follow_me.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_follow_me.a"; sourceTree = "<group>"; };
+		081FEE8E20347F21007422E2 /* libdronecore_action.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdronecore_action.a; path = "Yuneec_SDK_iOS/libs/Yuneec-SDK/lib/ios/libdronecore_action.a"; sourceTree = "<group>"; };
 		082C06551E150EAB00BDD785 /* Yuneec_SDK_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Yuneec_SDK_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		082C06581E150EAB00BDD785 /* Yuneec_SDK_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Yuneec_SDK_iOS.h; sourceTree = "<group>"; };
 		082C06591E150EAB00BDD785 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -66,10 +86,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1F02BB9F1FBD08DA00F9B384 /* libdronecore.a in Frameworks */,
+				081FEE9120347F43007422E2 /* libz.tbd in Frameworks */,
+				081FEE9020347F38007422E2 /* Security.framework in Frameworks */,
+				081FEE8F20347F21007422E2 /* libdronecore_action.a in Frameworks */,
+				081FEE8320347F21007422E2 /* libdronecore_camera.a in Frameworks */,
+				081FEE8520347F21007422E2 /* libdronecore_gimbal.a in Frameworks */,
+				081FEE8620347F21007422E2 /* libdronecore_info.a in Frameworks */,
+				081FEE8920347F21007422E2 /* libdronecore_mission.a in Frameworks */,
+				081FEE8A20347F21007422E2 /* libdronecore_offboard.a in Frameworks */,
+				081FEE8B20347F21007422E2 /* libdronecore_telemetry.a in Frameworks */,
+				08272CC9202B3B8A00C9B3F4 /* libdronecore.a in Frameworks */,
 				1F02BB9D1FBD08DA00F9B384 /* libcurl.a in Frameworks */,
-				0842318F1F587272001E53DA /* libz.tbd in Frameworks */,
-				0842318D1F58725F001E53DA /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -123,6 +150,19 @@
 		082C067C1E155F7D00BDD785 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				081FEE8E20347F21007422E2 /* libdronecore_action.a */,
+				081FEE6B203475D1007422E2 /* libdronecore_calibration.a */,
+				081FEE72203475D2007422E2 /* libdronecore_camera.a */,
+				081FEE75203475D2007422E2 /* libdronecore_follow_me.a */,
+				081FEE6F203475D2007422E2 /* libdronecore_gimbal.a */,
+				081FEE6E203475D2007422E2 /* libdronecore_info.a */,
+				081FEE71203475D2007422E2 /* libdronecore_logging.a */,
+				081FEE73203475D2007422E2 /* libdronecore_manual.a */,
+				081FEE70203475D2007422E2 /* libdronecore_mission.a */,
+				081FEE6D203475D2007422E2 /* libdronecore_offboard.a */,
+				081FEE74203475D2007422E2 /* libdronecore_telemetry.a */,
+				081FEE6A203475D1007422E2 /* libdronecore_update.a */,
+				081FEE6C203475D1007422E2 /* libdronecore_yuneec_st16.a */,
 				1F02BB9E1FBD08DA00F9B384 /* libdronecore.a */,
 				0842318E1F587272001E53DA /* libz.tbd */,
 				0842318C1F58725F001E53DA /* Security.framework */,

--- a/Yuneec_SDK_iOS/YNCSDKAction.mm
+++ b/Yuneec_SDK_iOS/YNCSDKAction.mm
@@ -32,34 +32,34 @@ void receive_action_error(YNCActionCompletion completion, Action::Result result)
 @implementation YNCAction
 
 + (void)armWithCompletion:(YNCActionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().action().arm_async(std::bind(&receive_action_error, completion, _1));
+    Action *action = [[YNCSDKInternal instance] action];
+    action->arm_async(std::bind(&receive_action_error, completion, _1));
 }
 
 + (void)disarmWithCompletion:(YNCActionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().action().disarm_async(std::bind(&receive_action_error, completion, _1));
+    Action *action = [[YNCSDKInternal instance] action];
+    action->disarm_async(std::bind(&receive_action_error, completion, _1));
 }
 
 + (void)takeoffWithCompletion:(YNCActionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    //dc->device().action().set_takeoff_altitude(1.0);
-    dc->device().action().takeoff_async(std::bind(&receive_action_error, completion, _1));
+    Action *action = [[YNCSDKInternal instance] action];
+    //action->set_takeoff_altitude(1.0);
+    action->takeoff_async(std::bind(&receive_action_error, completion, _1));
 }
 
 + (void)landWithCompletion:(YNCActionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().action().land_async(std::bind(&receive_action_error, completion, _1));
+    Action *action = [[YNCSDKInternal instance] action];
+    action->land_async(std::bind(&receive_action_error, completion, _1));
 }
 
 + (void)doReturnToLaunchWithCompletion:(YNCActionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().action().return_to_launch_async(std::bind(&receive_action_error, completion, _1));
+    Action *action = [[YNCSDKInternal instance] action];
+    action->return_to_launch_async(std::bind(&receive_action_error, completion, _1));
 }
 
 + (void)killWithCompletion:(YNCActionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().action().kill_async(std::bind(&receive_action_error, completion, _1));
+    Action *action = [[YNCSDKInternal instance] action];
+    action->kill_async(std::bind(&receive_action_error, completion, _1));
 }
 
 @end

--- a/Yuneec_SDK_iOS/YNCSDKCamera.mm
+++ b/Yuneec_SDK_iOS/YNCSDKCamera.mm
@@ -1,7 +1,6 @@
 /** @brief YNCSDKCamera  implementation file */
 
 #import "YNCSDKCamera.h"
-
 #import "YNCSDKInternal.h"
 
 #include <dronecore/dronecore.h>
@@ -849,8 +848,8 @@ void receive_capture_info(Camera::CaptureInfo captureInfo) {
 
 -(void) subscribe:(id<YNCSDKCameraCaptureInfoDelegate>)delegate {
     _captureInfoDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().capture_info_async(&receive_capture_info);
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->capture_info_async(&receive_capture_info);
 }
 @end
 
@@ -858,143 +857,143 @@ void receive_capture_info(Camera::CaptureInfo captureInfo) {
 
 //MARK: get Camera Mode
 + (void)getColorModeWithCompletion:(YNCColorModeCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_color_mode_async(std::bind(&receive_color_mode_result, completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_color_mode_async(std::bind(&receive_color_mode_result, completion, _1, _2));
 }
 
 //MARK: set Color Mode
 + (void)setColorMode:(YNCCameraColorMode)colorMode WithCompletion:(YNCColorModeCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::ColorMode cameraColorMode = getColorModeEnum(colorMode);
-    dc->device().camera().set_color_mode_async(cameraColorMode, std::bind(&receive_color_mode_result, completion, _1, _2));
+    camera->set_color_mode_async(cameraColorMode, std::bind(&receive_color_mode_result, completion, _1, _2));
 }
 
 //MARK: get White Balance Setting
 + (void)getWhiteBalanceWithCompletion:(YNCWhiteBalanceSettingCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_white_balance_async(std::bind(&receive_white_balance_result, completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_white_balance_async(std::bind(&receive_white_balance_result, completion, _1, _2));
 }
 
 //MARK: set White Balance
 
 + (void)setWhiteBalance:(YNCCameraWhiteBalance)whiteBalance WithCompletion:(YNCWhiteBalanceSettingCompletion)completion{
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::WhiteBalance cameraWhiteBalance = getWhiteBalanceEnum(whiteBalance);
-    dc->device().camera().set_white_balance_async(cameraWhiteBalance, std::bind(&receive_white_balance_result, completion, _1, _2));
+    camera->set_white_balance_async(cameraWhiteBalance, std::bind(&receive_white_balance_result, completion, _1, _2));
 }
 
 //MARK: get Exposure Mode
 + (void)getExposureModeWithCompletion:(YNCExposureModeCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_exposure_mode_async(std::bind(&receive_exposure_mode_result, completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_exposure_mode_async(std::bind(&receive_exposure_mode_result, completion, _1, _2));
 }
 
 //MARK: set Exposure Mode
 + (void)setExposureMode:(YNCCameraExposureMode)exposureMode WithCompletion:(YNCExposureModeCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::ExposureMode cameraExposureMode = getExposureModeEnum(exposureMode);
-    dc->device().camera().set_exposure_mode_async(cameraExposureMode, std::bind(&receive_exposure_mode_result, completion, _1, _2));
+    camera->set_exposure_mode_async(cameraExposureMode, std::bind(&receive_exposure_mode_result, completion, _1, _2));
 }
 
 //MARK: get Resolution
 + (void)getResolutionWithCompletion:(YNCCameraResolutionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_resolution_async(std::bind(&receive_resolution_result,completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_resolution_async(std::bind(&receive_resolution_result,completion, _1, _2));
 }
 
 //MARK: get Photo Format
 + (void)getPhotoFormatWithCompletion:(YNCPhotoFormatCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_photo_format_async(std::bind(&receive_photo_format_result,completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_photo_format_async(std::bind(&receive_photo_format_result,completion, _1, _2));
 }
 
 //MARK: set Photo Format
 + (void)setPhotoFormat:(YNCCameraPhotoFormat)photoFormat WithCompletion:(YNCPhotoFormatCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::PhotoFormat cameraPhotoFormat = getPhotoFormatEnum(photoFormat);
-    dc->device().camera().set_photo_format_async(cameraPhotoFormat, std::bind(&receive_photo_format_result, completion, _1, _2));
+    camera->set_photo_format_async(cameraPhotoFormat, std::bind(&receive_photo_format_result, completion, _1, _2));
 }
 
 //MARK: get Video Format
 + (void)getVideoFormatWithCompletion:(YNCVideoFormatCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_video_format_async(std::bind(&receive_video_format_result,completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_video_format_async(std::bind(&receive_video_format_result,completion, _1, _2));
 }
 
 //MARK: set Video Format
 + (void)setVideoFormat:(YNCCameraVideoFormat)videoFormat WithCompletion:(YNCVideoFormatCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::VideoFormat cameraVideoFormat = getVideoFormatEnum(videoFormat);
-    dc->device().camera().set_video_format_async(cameraVideoFormat, std::bind(&receive_video_format_result, completion, _1, _2));
+    camera->set_video_format_async(cameraVideoFormat, std::bind(&receive_video_format_result, completion, _1, _2));
 }
 
 //MARK: get Photo Quality
 + (void)getPhotoQualityWithCompletion:(YNCPhotoQualityCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_photo_quality_async(std::bind(&receive_photo_quality_result,completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_photo_quality_async(std::bind(&receive_photo_quality_result,completion, _1, _2));
 }
 
 //MARK: set Photo Quality
 + (void)setPhotoQuality:(YNCCameraPhotoQuality)photoQuality WithCompletion:(YNCPhotoQualityCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::PhotoQuality cameraPhotoQuality = getPhotoQualityEnum(photoQuality);
-    dc->device().camera().set_photo_quality_async(cameraPhotoQuality, std::bind(&receive_photo_quality_result, completion, _1, _2));
+    camera->set_photo_quality_async(cameraPhotoQuality, std::bind(&receive_photo_quality_result, completion, _1, _2));
 }
 
 //MARK: get Video Resolution
 + (void)getVideoResolutionWithCompletion:(YNCVideoResolutionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_video_resolution_async(std::bind(&receive_video_resolution_result,completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_video_resolution_async(std::bind(&receive_video_resolution_result,completion, _1, _2));
 }
 
 //MARK: set Video Resolution
 + (void)setVideoResolution:(YNCCameraVideoResolution)videoResolution WithCompletion:(YNCVideoResolutionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::VideoResolution cameraVideoResolution = getVideoResolutionEnum(videoResolution);
-    dc->device().camera().set_video_resolution_async(cameraVideoResolution, std::bind(&receive_video_resolution_result, completion, _1, _2));
+    camera->set_video_resolution_async(cameraVideoResolution, std::bind(&receive_video_resolution_result, completion, _1, _2));
 }
 
 //MARK: get Shutter Speed
 + (void)getShutterSpeedWithCompletion:(YNCShutterSpeedCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_shutter_speed_async(std::bind(&receive_shutter_speed_result,completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_shutter_speed_async(std::bind(&receive_shutter_speed_result,completion, _1, _2));
 }
 
 //MARK: set Shutter Speed
 + (void)setShutterSpeed:(YNCCameraShutterSpeed *)shutterSpeed WithCompletion:(YNCShutterSpeedCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::ShutterSpeedS tmpShutterSpeed;
     tmpShutterSpeed.numerator = shutterSpeed.numerator;
     tmpShutterSpeed.denominator = shutterSpeed.denominator;
-    dc->device().camera().set_shutter_speed_async(tmpShutterSpeed, std::bind(&receive_shutter_speed_result, completion, _1, _2));
+    camera->set_shutter_speed_async(tmpShutterSpeed, std::bind(&receive_shutter_speed_result, completion, _1, _2));
 }
 
 //MARK: get ISO value
 + (void)getISOValueWithCompletion:(YNCISOValueCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_iso_value_async(std::bind(&receive_iso_value_result, completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_iso_value_async(std::bind(&receive_iso_value_result, completion, _1, _2));
 }
 
 //MARK: set ISO value
 + (void)setISOValue:(int)isoValue WithCompletion:(YNCISOValueCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().set_iso_value_async(isoValue, std::bind(&receive_iso_value_result, completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->set_iso_value_async(isoValue, std::bind(&receive_iso_value_result, completion, _1, _2));
 }
 
 //MARK: get Metering
 + (void)getMeteringWithCompletion:(YNCMeteringCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_metering_async(std::bind(&receive_metering_result,completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_metering_async(std::bind(&receive_metering_result,completion, _1, _2));
 }
 
 //MARK: set Metering
 + (void)setMetering:(YNCCameraMetering *)metering WithCompletion:(YNCMeteringCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::Metering tmpMetering;
     tmpMetering.spot_screen_width_percent = metering.spotScreenWidthPercent;
     tmpMetering.spot_screen_height_percent = metering.spotScreenHeightPercent;
     tmpMetering.mode = getMeteringModeEnum(metering.mode);
-    dc->device().camera().set_metering_async(tmpMetering, std::bind(&receive_metering_result, completion, _1, _2));
+    camera->set_metering_async(tmpMetering, std::bind(&receive_metering_result, completion, _1, _2));
 }
 
 @end
@@ -1003,63 +1002,63 @@ void receive_capture_info(Camera::CaptureInfo captureInfo) {
 
 //MARK: Camera TakePhoto
 + (void)takePhotoWithCompletion:(YNCCameraCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().take_photo_async(std::bind(&receive_camera_result, completion, _1));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->take_photo_async(std::bind(&receive_camera_result, completion, _1));
 }
 
 //MARK: Camera StartVideo
 + (void)startVideoWithCompletion:(YNCCameraCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().start_video_async(std::bind(&receive_camera_result, completion, _1));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->start_video_async(std::bind(&receive_camera_result, completion, _1));
 }
 
 //MARK: Camera StopVideo
 + (void)stopVideoWithCompletion:(YNCCameraCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().stop_video_async(std::bind(&receive_camera_result, completion, _1));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->stop_video_async(std::bind(&receive_camera_result, completion, _1));
 }
 
 //MARK: Camera StartPhotoInterval
 + (void)startPhotoInterval:(double)intervalS Completion:(YNCCameraCompletion)completion{
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().start_photo_interval_async(intervalS, std::bind(&receive_camera_result, completion, _1));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->start_photo_interval_async(intervalS, std::bind(&receive_camera_result, completion, _1));
 }
 
 //MARK: Camera StopPhotoInterval
 + (void)stopPhotoIntervalWithCompletion:(YNCCameraCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().stop_photo_interval_async(std::bind(&receive_camera_result, completion, _1));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->stop_photo_interval_async(std::bind(&receive_camera_result, completion, _1));
 }
 
 //MARK: set camera mode
 + (void) setCameraMode:(YNCCameraMode)cameraMode WithCompletion:(YNCCameraModeCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Camera *camera = [[YNCSDKInternal instance] camera];
     Camera::Mode cameraModeVal = getCameraModeEnum(cameraMode);
-    dc->device().camera().set_mode_async(cameraModeVal, std::bind(&receive_camera_mode_result, completion, _1, _2));
+    camera->set_mode_async(cameraModeVal, std::bind(&receive_camera_mode_result, completion, _1, _2));
 }
 
 //MARK: get camera mode
 + (void) getCameraModeWithCompletion:(YNCCameraModeCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_mode_async(std::bind(&receive_camera_mode_result, completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_mode_async(std::bind(&receive_camera_mode_result, completion, _1, _2));
 }
 
 //MARK: get camera status
 + (void) getCameraStatusWithCompletion:(YNCCameraStatusCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_status_async(std::bind(&receive_camera_status_result, completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_status_async(std::bind(&receive_camera_status_result, completion, _1, _2));
 }
 
 //MARK: get all media info
 + (void) getMediaInfosWithCompletion:(YNCCameraMediaInfosCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_media_infos_async(std::bind(&receive_camera_all_media_result,completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_media_infos_async(std::bind(&receive_camera_all_media_result,completion, _1, _2));
 }
 
 //MARK: get media
 + (void) getMedia:(NSString *)localPath WithUrl:(NSString *)path WithCompletion:(YNCCameraMediaCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().camera().get_media_async(std::string([localPath UTF8String]), std::string([path UTF8String]), std::bind(&receive_camera_media_result,completion, _1, _2));
+    Camera *camera = [[YNCSDKInternal instance] camera];
+    camera->get_media_async(std::string([localPath UTF8String]), std::string([path UTF8String]), std::bind(&receive_camera_media_result,completion, _1, _2));
 }
 
 @end

--- a/Yuneec_SDK_iOS/YNCSDKGimbal.mm
+++ b/Yuneec_SDK_iOS/YNCSDKGimbal.mm
@@ -29,8 +29,8 @@ void receive_gimbal_result(YNCGimbalCompletion completion, Gimbal::Result result
 
 //MARK: Set PitchAndYaw
 + (void)setPitchDeg:(float)pitchDeg andYawDeg:(float)yawDeg withCompletion:(YNCGimbalCompletion)completion{
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().gimbal().set_pitch_and_yaw_async(pitchDeg, yawDeg, std::bind(&receive_gimbal_result, completion, _1));
+    Gimbal *gimbal = [[YNCSDKInternal instance] gimbal];
+    gimbal->set_pitch_and_yaw_async(pitchDeg, yawDeg, std::bind(&receive_gimbal_result, completion, _1));
 }
 
 @end

--- a/Yuneec_SDK_iOS/YNCSDKInternal.h
+++ b/Yuneec_SDK_iOS/YNCSDKInternal.h
@@ -10,6 +10,12 @@
 #import <Foundation/Foundation.h>
 
 #include <dronecore/dronecore.h>
+#include <dronecore/action.h>
+#include <dronecore/mission.h>
+#include <dronecore/telemetry.h>
+#include <dronecore/camera.h>
+#include <dronecore/gimbal.h>
+#include <dronecore/offboard.h>
 
 
 /*
@@ -21,6 +27,12 @@
  Dronecore object
  */
 @property (nonatomic) dronecore::DroneCore *dc;
+@property (nonatomic) dronecore::Action *action;
+@property (nonatomic) dronecore::Mission *mission;
+@property (nonatomic) dronecore::Telemetry *telemetry;
+@property (nonatomic) dronecore::Camera *camera;
+@property (nonatomic) dronecore::Gimbal *gimbal;
+@property (nonatomic) dronecore::Offboard *offboard;
 
 + (id)instance;
 

--- a/Yuneec_SDK_iOS/YNCSDKInternal.mm
+++ b/Yuneec_SDK_iOS/YNCSDKInternal.mm
@@ -17,17 +17,29 @@ using namespace dronecore;
     dispatch_once(&onceToken, ^{
         temp = [[self alloc] init];
     });
-    
+
     return temp;
 }
 
 - (instancetype)init {
     self = [super init];
     _dc = new DroneCore;
+    _action = new Action(&_dc->device());
+    _mission = new Mission(&_dc->device());
+    _telemetry = new Telemetry(&_dc->device());
+    _camera = new Camera(&_dc->device());
+    _gimbal = new Gimbal(&_dc->device());
+    _offboard = new Offboard(&_dc->device());
     return self;
 }
 
 - (void)resetDroneCore {
+    delete _action;
+    delete _mission;
+    delete _telemetry;
+    delete _camera;
+    delete _gimbal;
+    delete _offboard;
     delete _dc;
     _dc = nullptr;
 }

--- a/Yuneec_SDK_iOS/YNCSDKMission.mm
+++ b/Yuneec_SDK_iOS/YNCSDKMission.mm
@@ -40,7 +40,7 @@ void receive_mission_progress(YNCMissionProgressCallbackBlock callback, int curr
 
 + (void)sendMissionWithMissionItems:(NSMutableArray *)missionItems
                      withCompletion:(YNCMissionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
+    Mission *mission = [[YNCSDKInternal instance] mission];
     std::vector<std::shared_ptr<MissionItem>> std_vec;
 
     for (YNCSDKMissionItem *missionItem in missionItems) {
@@ -54,22 +54,22 @@ void receive_mission_progress(YNCMissionProgressCallbackBlock callback, int curr
         std_vec.push_back(newItem);
     }
 
-    dc->device().mission().upload_mission_async(std_vec, std::bind(&receive_mission_error, completion, _1));
+    mission->upload_mission_async(std_vec, std::bind(&receive_mission_error, completion, _1));
 }
 
 + (void)startMissionWithCompletion:(YNCMissionCompletion)completion{
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().mission().start_mission_async(std::bind(&receive_mission_error, completion, _1));
+    Mission *mission = [[YNCSDKInternal instance] mission];
+    mission->start_mission_async(std::bind(&receive_mission_error, completion, _1));
 }
 
 + (void)pauseMissionWithCompletion:(YNCMissionCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().mission().pause_mission_async(std::bind(&receive_mission_error, completion, _1));
+    Mission *mission = [[YNCSDKInternal instance] mission];
+    mission->pause_mission_async(std::bind(&receive_mission_error, completion, _1));
 }
 
 + (void)subscribeProgressWithCallback:(YNCMissionProgressCallbackBlock)callback {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().mission().subscribe_progress(std::bind(&receive_mission_progress, callback, _1, _2));
+    Mission *mission = [[YNCSDKInternal instance] mission];
+    mission->subscribe_progress(std::bind(&receive_mission_progress, callback, _1, _2));
 }
 
 + (MissionItem::CameraAction)convertIntToCameraAction:(YNCCameraAction)raw {

--- a/Yuneec_SDK_iOS/YNCSDKOffboard.h
+++ b/Yuneec_SDK_iOS/YNCSDKOffboard.h
@@ -21,9 +21,9 @@ typedef void (^YNCOffboardCompletion)(NSError *error);
 
 /**
  * Starts the offboard (manual) control mode.
- * 
+ *
  * This requires that a velocity waypoint has already been set.
- * 
+ *
  * @param completion the completion block returning the error status, if any
  */
 + (void)startWithCompletion:(YNCOffboardCompletion)completion;
@@ -32,14 +32,14 @@ typedef void (^YNCOffboardCompletion)(NSError *error);
  * Stops the offboard (manual) control mode.
  *
  * The drone will go back to pause mode and hold its position.
- * 
+ *
  * @param completion the completion block returning the error status, if any
  */
 + (void)stopWithCompletion:(YNCOffboardCompletion)completion;
 
 /**
  Sets the drone velocity in ground coordinates. You should set a speed every 30ms to ensure smooth flight operation.
- 
+
  @param velocityNorth the north direction ground speed (m/s)
  @param velocityEast the east direction ground speed (m/s)
  @param velocityDown the down direction ground speed (m/s)

--- a/Yuneec_SDK_iOS/YNCSDKOffboard.mm
+++ b/Yuneec_SDK_iOS/YNCSDKOffboard.mm
@@ -31,43 +31,43 @@ void receive_offboard_error(YNCOffboardCompletion completion, Offboard::Result r
 }
 
 + (void)startWithCompletion:(YNCOffboardCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().offboard().start_async(std::bind(&receive_offboard_error, completion, _1));
+    Offboard *offboard = [[YNCSDKInternal instance] offboard];
+    offboard->start_async(std::bind(&receive_offboard_error, completion, _1));
 }
 
 + (void)stopWithCompletion:(YNCOffboardCompletion)completion {
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().offboard().stop_async(std::bind(&receive_offboard_error, completion, _1));
+    Offboard *offboard = [[YNCSDKInternal instance] offboard];
+    offboard->stop_async(std::bind(&receive_offboard_error, completion, _1));
 }
 
 + (void)setVelocityNEDYawWithVelocityNorth:(float)velocityNorth
                           withVelocityEast:(float)velocityEast
                           withVelocityDown:(float)velocityDown
                                    withYaw:(float)yawDeg {
-    
+
     Offboard::VelocityNEDYaw vNEDYaw;
     vNEDYaw.north_m_s = velocityNorth;
     vNEDYaw.east_m_s = velocityEast;
     vNEDYaw.down_m_s = velocityDown;
     vNEDYaw.yaw_deg = yawDeg;
-    
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().offboard().set_velocity_ned(vNEDYaw);
+
+    Offboard *offboard = [[YNCSDKInternal instance] offboard];
+    offboard->set_velocity_ned(vNEDYaw);
 }
 
 + (void)setVelocityBodyYawspeedWithVelocityForward:(float)velocityForward
                                  withVelocityRight:(float)velocityRight
                                   withVelocityDown:(float)velocityDown
                                      witchYawspeed:(float)yawspeed {
-    
+
     Offboard::VelocityBodyYawspeed vBodyYawspeed;
     vBodyYawspeed.forward_m_s = velocityForward;
     vBodyYawspeed.right_m_s = velocityRight;
     vBodyYawspeed.down_m_s = velocityDown;
     vBodyYawspeed.yawspeed_deg_s = yawspeed;
-    
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().offboard().set_velocity_body(vBodyYawspeed);
+
+    Offboard *offboard = [[YNCSDKInternal instance] offboard];
+    offboard->set_velocity_body(vBodyYawspeed);
 }
 
 @end

--- a/Yuneec_SDK_iOS/YNCSDKTelemetry.mm
+++ b/Yuneec_SDK_iOS/YNCSDKTelemetry.mm
@@ -31,7 +31,7 @@ void receive_battery(Telemetry::Battery battery) {
     YNCBattery *tmpBattery = [YNCBattery new];
     tmpBattery.voltageV = battery.voltage_v;
     tmpBattery.remainingPercent = battery.remaining_percent;
-    
+
     if (_batteryDelegate && [_batteryDelegate respondsToSelector:@selector(onBatteryUpdate:)]) {
         [_batteryDelegate onBatteryUpdate:tmpBattery];
     }
@@ -44,7 +44,7 @@ void receive_position(Telemetry::Position position) {
     tmpPosition.longitudeDeg = position.longitude_deg;
     tmpPosition.absoluteAltitudeM = position.absolute_altitude_m;
     tmpPosition.relativeAltitudeM = position.relative_altitude_m;
-    
+
     if (_positionDelegate &&
         [_positionDelegate respondsToSelector:@selector(onPositionUpdate:)]) {
         [_positionDelegate onPositionUpdate:tmpPosition];
@@ -57,7 +57,7 @@ void receive_ground_speed_ned(Telemetry::GroundSpeedNED ground_speed_ned) {
     tmpSpeed.velocityNorthMS = ground_speed_ned.velocity_north_m_s;
     tmpSpeed.velocityEastMS = ground_speed_ned.velocity_east_m_s;
     tmpSpeed.velocityDownMS = ground_speed_ned.velocity_down_m_s;
-    
+
     if (_groundSpeedNEDDelegate &&
         [_groundSpeedNEDDelegate respondsToSelector:@selector(onGroundSpeedNEDUpdate:)]) {
         [_groundSpeedNEDDelegate onGroundSpeedNEDUpdate:tmpSpeed];
@@ -69,7 +69,7 @@ void receive_GPSInfo(Telemetry::GPSInfo gpsInfo) {
     YNCGPSInfo *tmpGPSInfo = [YNCGPSInfo new];
     tmpGPSInfo.numSatellites = gpsInfo.num_satellites;
     tmpGPSInfo.fixType = gpsInfo.fix_type;
-    
+
     if (_gpsInfoDelegate &&
         [_gpsInfoDelegate respondsToSelector:@selector(onGPSInfoUpdate:)]) {
         [_gpsInfoDelegate onGPSInfoUpdate:tmpGPSInfo];
@@ -82,7 +82,7 @@ void receive_attitudeEulerAngle(Telemetry::EulerAngle eulerAngle) {
     tmpEulerAngle.pitchDeg = eulerAngle.pitch_deg;
     tmpEulerAngle.rollDeg = eulerAngle.roll_deg;
     tmpEulerAngle.yawDeg = eulerAngle.yaw_deg;
-    
+
     if (_attitudeEulerAngleDelegate &&
         [_attitudeEulerAngleDelegate respondsToSelector:@selector(onAttitudeEulerAngleUpdate:)]) {
         [_attitudeEulerAngleDelegate onAttitudeEulerAngleUpdate:tmpEulerAngle];
@@ -96,7 +96,7 @@ void receive_attitudeQuaternion(Telemetry::Quaternion quaternion) {
     tmpQuaternion.x = quaternion.x;
     tmpQuaternion.y = quaternion.y;
     tmpQuaternion.z = quaternion.z;
-    
+
     if (_attitudeQuaternionDelegate &&
         [_attitudeQuaternionDelegate respondsToSelector:@selector(onAttitudeQuaternionUpdate:)]) {
         [_attitudeQuaternionDelegate onAttitudeQuaternionUpdate:tmpQuaternion];
@@ -110,7 +110,7 @@ void receive_homePosition(Telemetry::Position homePosition) {
     tmpHomePosition.longitudeDeg = homePosition.longitude_deg;
     tmpHomePosition.absoluteAltitudeM = homePosition.absolute_altitude_m;
     tmpHomePosition.relativeAltitudeM = homePosition.relative_altitude_m;
-    
+
     if (_homePositionDelegate &&
         [_homePositionDelegate respondsToSelector:@selector(onHomePositionUpdate:)]) {
         [_homePositionDelegate onHomePositionUpdate:tmpHomePosition];
@@ -130,7 +130,7 @@ void receive_CameraAttitudeEulerAngle(Telemetry::EulerAngle eulerAngle) {
     tmpAttitude.pitchDeg = eulerAngle.pitch_deg;
     tmpAttitude.rollDeg = eulerAngle.roll_deg;
     tmpAttitude.yawDeg = eulerAngle.yaw_deg;
-    
+
     if (_cameraAttitudeEulerAngleDelegate &&
         [_cameraAttitudeEulerAngleDelegate respondsToSelector:@selector(onCameraAttitudeEulerAngleUpdate:)]) {
         [_cameraAttitudeEulerAngleDelegate onCameraAttitudeEulerAngleUpdate:tmpAttitude];
@@ -144,7 +144,7 @@ void receive_CameraAttitudeQuaternion(Telemetry::Quaternion quaternion) {
     tmpAttitude.x = quaternion.x;
     tmpAttitude.y = quaternion.y;
     tmpAttitude.z = quaternion.z;
-    
+
     if (_cameraAttitudeQuaternionDelegate &&
         [_cameraAttitudeQuaternionDelegate respondsToSelector:@selector(onCameraAttitudeQuaternionUpdate:)]) {
         [_cameraAttitudeQuaternionDelegate onCameraAttitudeQuaternionUpdate:tmpAttitude];
@@ -157,7 +157,7 @@ void receive_RCStatus(Telemetry::RCStatus RCStatus) {
     tmpRCStatus.availableOnce = RCStatus.available_once;
     tmpRCStatus.lost = !RCStatus.available;
     tmpRCStatus.signalStrengthPercent = RCStatus.signal_strength_percent;
-    
+
     if (_rcStatusDelegate &&
         [_rcStatusDelegate respondsToSelector:@selector(onRCStatusUpdate:)]) {
         [_rcStatusDelegate onRCStatusUpdate:tmpRCStatus];
@@ -167,42 +167,42 @@ void receive_RCStatus(Telemetry::RCStatus RCStatus) {
 #pragma mark Flight Mode information
 void receive_flightMode(Telemetry::FlightMode flightMode) {
     YNCTelemetryFlightMode tmpFlightMode;
-    
+
     switch (flightMode) {
         case Telemetry::FlightMode::READY:
             tmpFlightMode = YNCREADY;
             break;
-            
+
         case Telemetry::FlightMode::TAKEOFF:
             tmpFlightMode = YNCTAKEOFF;
             break;
-            
+
         case Telemetry::FlightMode::HOLD:
             tmpFlightMode = YNCHOLD;
             break;
-            
+
         case Telemetry::FlightMode::MISSION:
             tmpFlightMode = YNCMISSION;
             break;
-            
+
         case Telemetry::FlightMode::RETURN_TO_LAUNCH:
             tmpFlightMode = YNCRETURN_TO_LAUNCH;
             break;
-            
+
         case Telemetry::FlightMode::LAND:
             tmpFlightMode = YNCLAND;
             break;
-            
+
         case Telemetry::FlightMode::OFFBOARD:
             tmpFlightMode = YNCOFFBOARD;
             break;
-           
+
         case Telemetry::FlightMode::UNKNOWN:
         default:
             tmpFlightMode = YNCUNKNOWN;
             break;
     }
-    
+
     if (_flightModeDelegate &&
         [_flightModeDelegate respondsToSelector:@selector(onFlightModeUpdate:)]) {
         [_flightModeDelegate onFlightModeUpdate:tmpFlightMode];
@@ -219,7 +219,7 @@ void receive_health(Telemetry::Health health) {
     tmpHealth.gyrometerCalibrationOk = health.gyrometer_calibration_ok;
     tmpHealth.magnetometerCalibrationOk = health.magnetometer_calibration_ok;
     tmpHealth.accelerometerCalibrationOk = health.accelerometer_calibration_ok;
-    
+
     if (_healthDelegate &&
         [_healthDelegate respondsToSelector:@selector(onHealthUpdate:)]) {
         [_healthDelegate onHealthUpdate:tmpHealth];
@@ -247,8 +247,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryBatteryDelegate>) delegate {
     _batteryDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().battery_async(&receive_battery);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->battery_async(&receive_battery);
 }
 
 @end
@@ -260,8 +260,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryPositionDelegate>) delegate {
     _positionDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().position_async(&receive_position);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->position_async(&receive_position);
 }
 
 @end
@@ -273,8 +273,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryGroundSpeedNEDDelegate>) delegate {
     _groundSpeedNEDDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().ground_speed_ned_async(&receive_ground_speed_ned);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->ground_speed_ned_async(&receive_ground_speed_ned);
 }
 
 @end
@@ -286,8 +286,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryGPSInfoDelegate>) delegate {
     _gpsInfoDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().gps_info_async(&receive_GPSInfo);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->gps_info_async(&receive_GPSInfo);
 }
 
 @end
@@ -299,8 +299,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryAttitudeEulerAngleDelegate>) delegate {
     _attitudeEulerAngleDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().attitude_euler_angle_async(&receive_attitudeEulerAngle);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->attitude_euler_angle_async(&receive_attitudeEulerAngle);
 }
 
 @end
@@ -312,8 +312,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryAttitudeQuaternionDelegate>) delegate {
     _attitudeQuaternionDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().attitude_quaternion_async(&receive_attitudeQuaternion);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->attitude_quaternion_async(&receive_attitudeQuaternion);
 }
 
 @end
@@ -322,8 +322,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryHomePositionDelegate>) delegate {
     _homePositionDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().home_position_async(&receive_homePosition);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->home_position_async(&receive_homePosition);
 }
 
 @end
@@ -332,8 +332,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryInAirDelegate>) delegate {
     _inAirDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().in_air_async(&receive_inAir);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->in_air_async(&receive_inAir);
 }
 
 @end
@@ -342,8 +342,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryCameraAttitudeEulerAngleDelegate>) delegate {
     _cameraAttitudeEulerAngleDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().camera_attitude_euler_angle_async(&receive_attitudeEulerAngle);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->camera_attitude_euler_angle_async(&receive_attitudeEulerAngle);
 }
 
 @end
@@ -352,8 +352,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryCameraAttitudeQuaternionDelegate>) delegate {
     _cameraAttitudeQuaternionDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().camera_attitude_quaternion_async(&receive_attitudeQuaternion);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->camera_attitude_quaternion_async(&receive_attitudeQuaternion);
 }
 
 @end
@@ -365,8 +365,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryRCStatusDelegate>) delegate {
     _rcStatusDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().rc_status_async(&receive_RCStatus);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->rc_status_async(&receive_RCStatus);
 }
 
 @end
@@ -375,8 +375,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryFlightModeDelegate>) delegate {
     _flightModeDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().flight_mode_async(&receive_flightMode);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->flight_mode_async(&receive_flightMode);
 }
 
 @end
@@ -388,8 +388,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryHealthDelegate>) delegate {
     _healthDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().health_async(&receive_health);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->health_async(&receive_health);
 }
 
 @end
@@ -398,8 +398,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryArmedDelegate>) delegate {
     _armedDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().armed_async(&receive_armed);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->armed_async(&receive_armed);
 }
 
 @end
@@ -408,8 +408,8 @@ void receive_healthAllOk(bool healthAllOk) {
 
 - (void)subscribe:(id<YNCSDKTelemetryHealthAllOkDelegate>) delegate {
     _healthAllOkDelegate = delegate;
-    DroneCore *dc = [[YNCSDKInternal instance] dc];
-    dc->device().telemetry().health_all_ok_async(&receive_healthAllOk);
+    Telemetry *telemetry = [[YNCSDKInternal instance] telemetry];
+    telemetry->health_all_ok_async(&receive_healthAllOk);
 }
 
 @end

--- a/download-dronecore.sh
+++ b/download-dronecore.sh
@@ -2,7 +2,7 @@
 
 set -e # fail on errors
 
-dronecore_filename=DroneCore-iOS-v0.10.1-Release.zip
+dronecore_filename=DroneCore-iOS-v0.11.2-Release.zip
 unzip_dir=Yuneec_SDK_iOS/libs/Yuneec-SDK
 
 downloaded=false


### PR DESCRIPTION
A recent refactor in DroneCore changed the device and plugin API quite a
bit. Therefore this required some changes in the wrapper. Instead of
just getting the device from the internal singleton, we now get each of
the plugins from it.